### PR TITLE
Change deployment strategy to published release with demo dataset

### DIFF
--- a/.github/workflows/hugging-face-deployment.yml
+++ b/.github/workflows/hugging-face-deployment.yml
@@ -18,4 +18,4 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_USERNAME: ${{ vars.HF_USERNAME }}
-        run: git push --force https://$HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/$HF_USERNAME/pdf-explainer main
+        run: git push --force https://$HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/$HF_USERNAME/pdf-explainer refs/tags/${{ github.ref_name }}:main

--- a/.github/workflows/hugging-face-deployment.yml
+++ b/.github/workflows/hugging-face-deployment.yml
@@ -1,7 +1,7 @@
 name: Sync to Hugging Face hub
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
 
   # to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,8 @@ WORKDIR $HOME/app
 COPY . $HOME/app
 
 RUN mkdir -p $HOME/app/tmp/chroma
+RUN chmod +x $HOME/app/entrypoint.sh
 
 EXPOSE 8501
 
-CMD streamlit run GnosisPages.py \
-    --server.headless true \
-    --server.enableCORS false \
-    --server.enableXsrfProtection false \
-    --server.fileWatcherType none \
-    --server.port 8501
+CMD ["bash", "/home/user/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+python -c "from gnosis.persistence import pull; pull()"
+exec streamlit run GnosisPages.py \
+    --server.headless true \
+    --server.enableCORS false \
+    --server.enableXsrfProtection false \
+    --server.fileWatcherType none \
+    --server.port 8501

--- a/gnosis/persistence.py
+++ b/gnosis/persistence.py
@@ -1,0 +1,20 @@
+# Use this module to pull persisted ChromaDB from Hugging Face Dataset on startup.
+import os
+from huggingface_hub import snapshot_download
+
+REPO_ID = os.getenv("HF_DATASET_REPO")
+LOCAL_PATH = "tmp/chroma"
+
+def pull():
+    """Download persisted ChromaDB from HF Dataset on startup."""
+    if not REPO_ID:
+        return
+    try:
+        snapshot_download(
+            repo_id=REPO_ID,
+            repo_type="dataset",
+            local_dir=LOCAL_PATH,
+            token=os.getenv("HF_DATASET_TOKEN"),
+        )
+    except Exception:
+        os.makedirs(LOCAL_PATH, exist_ok=True)


### PR DESCRIPTION
This pull request introduces several improvements to the deployment and startup process, focusing on integrating a data-pulling step from Hugging Face on application startup, and modifying the deployment workflow to trigger on release events. The changes ensure that the application always has the latest persisted data from Hugging Face and streamline the deployment process.

**Deployment workflow updates:**

* The GitHub Actions workflow `.github/workflows/hugging-face-deployment.yml` now triggers on published releases instead of every push to `main`, ensuring deployments only occur for official releases.
* The workflow's push command now pushes the release tag to the Hugging Face `main` branch, improving version tracking and deployment accuracy.

**Application startup and Docker improvements:**

* Introduced a new `entrypoint.sh` script that pulls the latest ChromaDB data from Hugging Face using the `gnosis.persistence.pull()` function before starting the Streamlit app, ensuring up-to-date data on startup. [[1]](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R1-R8) [[2]](diffhunk://#diff-84cfe5803ede26dcb343d4d2eec86a5c3fc95bad3c58b4dd49ef9d4187d4b3a1R1-R20)
* Updated the `Dockerfile` to run the new `entrypoint.sh` script (with executable permissions) as the container's command, replacing the previous inline `CMD`.

**Data persistence logic:**

* Added `gnosis/persistence.py`, which defines the `pull()` function to download the ChromaDB dataset from Hugging Face on startup, using environment variables for configuration and handling missing datasets gracefully.