### PR TITLE
Allow edited releases to trigger Hugging Face sync

### DIFF
--- a/.github/workflows/hugging-face-deployment.yml
+++ b/.github/workflows/hugging-face-deployment.yml
@@ -1,7 +1,7 @@
 name: Sync to Hugging Face hub
 on:
   release:
-    types: [published]
+    types: [published, edited]
 
   # to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for Hugging Face deployment. The workflow will now trigger not only when a release is published, but also when a release is edited.